### PR TITLE
Elastic native client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN mkdir -p /opt/sinkit && chown sinkit /opt/sinkit && chgrp sinkit /opt/sinkit
 WORKDIR /opt/sinkit
 USER sinkit
 
-ENV WILDFLY_VERSION 10.0.0.CR5-SNAPSHOT
+ENV WILDFLY_VERSION 10.0.0.Final
 ENV HIBERNATE_HQL_LUCENE_VERSION 1.3.0.Alpha2
 ENV HIBERNATE_HQL_PARSER_VERSION 1.3.0.Alpha2
 ENV STRINGTEMPLATE_VERSION 3.2.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN mkdir -p /opt/sinkit && chown sinkit /opt/sinkit && chgrp sinkit /opt/sinkit
 WORKDIR /opt/sinkit
 USER sinkit
 
-ENV WILDFLY_VERSION 10.0.0.Final
+ENV WILDFLY_VERSION 10.0.0.CR5-SNAPSHOT
 ENV HIBERNATE_HQL_LUCENE_VERSION 1.3.0.Alpha2
 ENV HIBERNATE_HQL_PARSER_VERSION 1.3.0.Alpha2
 ENV STRINGTEMPLATE_VERSION 3.2.1

--- a/ejb/pom.xml
+++ b/ejb/pom.xml
@@ -228,6 +228,13 @@
             <version>${io.searchbox.jest.version}</version>
         </dependency>
 
+        <!-- Elastic search core -->
+        <dependency>
+            <groupId>org.elasticsearch</groupId>
+            <artifactId>elasticsearch</artifactId>
+            <version>${es.version}</version>
+        </dependency>
+
         <!--Import the JAX-RS API, we use provided scope as the API is included in JBoss WildFly-->
         <dependency>
             <groupId>org.jboss.resteasy</groupId>

--- a/ejb/src/main/java/biz/karms/sinkit/ejb/elastic/ElasticClientProvider.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ejb/elastic/ElasticClientProvider.java
@@ -1,0 +1,58 @@
+package biz.karms.sinkit.ejb.elastic;
+
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.node.Node;
+import org.elasticsearch.node.NodeBuilder;
+
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Created by Tomas Kozel
+ */
+@ApplicationScoped
+public class ElasticClientProvider {
+
+    @Inject
+    private Logger log;
+
+    private Client client;
+    private Node node;
+
+    public Client getClient() {
+        if (client == null) {
+            log.log(Level.INFO, "Elastic client doesn't exists, creating new one");
+            if (node == null) {
+                log.log(Level.INFO, "Elastic client node doesn't exists, creating new one");
+                node = NodeBuilder.nodeBuilder()
+                        .settings(ImmutableSettings.settingsBuilder().put("http.enabled", false))
+                        .client(true)
+                        .data(false)
+                        .node();
+            }
+            client = node.client();
+//            client = new TransportClient()
+//                    .addTransportAddress(new InetSocketTransportAddress("localhost", 9300));
+        }
+        return client;
+    }
+
+    @PreDestroy
+    public void shutDown() {
+        if (client != null) {
+            log.log(Level.INFO, "Closing elastic client");
+            client.close();
+        }
+        if (node != null) {
+            log.log(Level.INFO, "Closing elastic client node");
+            node.close();
+        }
+//        if (client != null) {
+//            client.close();
+//        }
+    }
+}

--- a/ejb/src/main/java/biz/karms/sinkit/ejb/elastic/ElasticResources.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ejb/elastic/ElasticResources.java
@@ -1,6 +1,7 @@
 package biz.karms.sinkit.ejb.elastic;
 
-import io.searchbox.client.JestClient;
+import com.google.gson.Gson;
+import org.elasticsearch.client.Client;
 
 import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.Default;
@@ -13,12 +14,32 @@ import javax.inject.Inject;
 @Dependent
 public class ElasticResources {
 
+    public static final String ELASTIC_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ssZ";
+
+//    @Inject
+//    private JestClientProvider jestClientProvider;
+
     @Inject
-    JestClientProvider jestClientProvider;
+    private ElasticClientProvider elasticClientProvider;
+
+    @Inject
+    private GsonProvider gsonProvider;
+
+//    @Produces
+//    @Default
+//    public JestClient getJestClient() {
+//        return jestClientProvider.getJestClient();
+//    }
 
     @Produces
     @Default
-    JestClient getJestClient() {
-        return jestClientProvider.getJestClient();
+    public Client getElasticClient() {
+        return elasticClientProvider.getClient();
+    }
+
+    @Produces
+    @Default
+    public Gson getGson() {
+        return gsonProvider.getGson();
     }
 }

--- a/ejb/src/main/java/biz/karms/sinkit/ejb/elastic/ElasticService.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ejb/elastic/ElasticService.java
@@ -1,6 +1,8 @@
 package biz.karms.sinkit.ejb.elastic;
 
 import biz.karms.sinkit.exception.ArchiveException;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.search.sort.SortBuilder;
 
 import javax.ejb.Local;
 import java.util.List;
@@ -10,17 +12,15 @@ import java.util.List;
  */
 @Local
 public interface ElasticService {
-    <T extends Indexable> T searchForSingleHit(String query, String index, String type, Class<T> clazz) throws ArchiveException;
-
     <T extends Indexable> T getDocumentById(String id, String index, String type, Class<T> clazz) throws ArchiveException;
 
-    <T extends Indexable> List<T> search(String query, String index, String type, Class<T> clazz) throws ArchiveException;
+    <T extends Indexable> List<T> search(QueryBuilder query, SortBuilder sort, String index, String type, Class<T> clazz) throws ArchiveException;
 
-    <T extends Indexable> List<T> search(String query, String index, String type, int from, int size, Class<T> clazz) throws ArchiveException;
+    <T extends Indexable> List<T> search(QueryBuilder query, SortBuilder sort, String index, String type, int from, int size, Class<T> clazz) throws ArchiveException;
 
     <T extends Indexable> T index(T document, String index, String type) throws ArchiveException;
 
-    boolean update(String documentId, String script, String index, String type) throws ArchiveException;
+    boolean update(String documentId, Object updateDoc, String index, String type, Object upsertDoc) throws ArchiveException;
 
     <T extends Indexable> boolean delete(T document, String index, String type) throws ArchiveException;
 }

--- a/ejb/src/main/java/biz/karms/sinkit/ejb/elastic/GsonProvider.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ejb/elastic/GsonProvider.java
@@ -1,0 +1,33 @@
+package biz.karms.sinkit.ejb.elastic;
+
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Created by Tomas Kozel
+ */
+@ApplicationScoped
+public class GsonProvider {
+
+    @Inject
+    private Logger log;
+
+    private Gson gson;
+
+    public Gson getGson() {
+        if (gson == null) {
+            log.log(Level.INFO, "Gson doesn't exist, creating new one");
+            gson = new GsonBuilder()
+                    .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+                    .setDateFormat(ElasticResources.ELASTIC_DATE_FORMAT)
+                    .create();
+        }
+        return gson;
+    }
+}

--- a/ejb/src/main/java/biz/karms/sinkit/ejb/elastic/JestClientProvider.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ejb/elastic/JestClientProvider.java
@@ -1,13 +1,6 @@
 package biz.karms.sinkit.ejb.elastic;
 
-import io.searchbox.client.JestClient;
-import io.searchbox.client.JestClientFactory;
-import io.searchbox.client.config.HttpClientConfig;
-
 import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * @author Tomas Kozel
@@ -15,31 +8,31 @@ import java.util.logging.Logger;
 @ApplicationScoped
 public class JestClientProvider {
 
-    @Inject
-    private Logger log;
-
-    private JestClient jestClient;
-
-    public JestClient getJestClient() {
-
-        if (this.jestClient == null) {
-            log.log(Level.INFO, "JestClient does not exist - constructing a new one");
-            final String elasticHost = System.getenv("SINKIT_ELASTIC_HOST");
-            final String elasticPort = System.getenv("SINKIT_ELASTIC_PORT");
-            if (elasticHost == null || elasticPort == null) {
-                log.log(Level.SEVERE, "SINKIT_ELASTIC_HOST and SINKIT_ELASTIC_PORT must be set.");
-            }
-            JestClientFactory factory = new JestClientFactory();
-            factory.setHttpClientConfig(new HttpClientConfig
-                    .Builder("http://" + elasticHost + ":" + elasticPort)
-                    .multiThreaded(true)
-                    .connTimeout(10000)
-                    .readTimeout(10000)
-                    .build());
-
-            this.jestClient = factory.getObject();
-        }
-
-        return jestClient;
-    }
+//    @Inject
+//    private Logger log;
+//
+//    private JestClient jestClient;
+//
+//    public JestClient getJestClient() {
+//
+//        if (this.jestClient == null) {
+//            log.log(Level.INFO, "JestClient does not exist - constructing a new one");
+//            final String elasticHost = System.getenv("SINKIT_ELASTIC_HOST");
+//            final String elasticPort = System.getenv("SINKIT_ELASTIC_PORT");
+//            if (elasticHost == null || elasticPort == null) {
+//                log.log(Level.SEVERE, "SINKIT_ELASTIC_HOST and SINKIT_ELASTIC_PORT must be set.");
+//            }
+//            JestClientFactory factory = new JestClientFactory();
+//            factory.setHttpClientConfig(new HttpClientConfig
+//                    .Builder("http://" + elasticHost + ":" + elasticPort)
+//                    .multiThreaded(true)
+//                    .connTimeout(10000)
+//                    .readTimeout(10000)
+//                    .build());
+//
+//            this.jestClient = factory.getObject();
+//        }
+//
+//        return jestClient;
+//    }
 }

--- a/ejb/src/main/java/biz/karms/sinkit/ejb/elastic/impl/ElasticNativeServiceEJB.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ejb/elastic/impl/ElasticNativeServiceEJB.java
@@ -1,0 +1,185 @@
+package biz.karms.sinkit.ejb.elastic.impl;
+
+import biz.karms.sinkit.ejb.elastic.ElasticService;
+import biz.karms.sinkit.ejb.elastic.Indexable;
+import biz.karms.sinkit.exception.ArchiveException;
+import com.google.gson.Gson;
+import org.elasticsearch.action.delete.DeleteResponse;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.search.SearchRequestBuilder;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchType;
+import org.elasticsearch.action.update.UpdateRequestBuilder;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.sort.SortBuilder;
+
+import javax.annotation.PostConstruct;
+import javax.ejb.Stateless;
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Created by tkozel on 2/27/16.
+ */
+@Stateless
+public class ElasticNativeServiceEJB implements ElasticService {
+
+    private static final int DEF_LIMIT = 1000;
+
+    @Inject
+    private Logger log;
+
+    @Inject
+    private Client client;
+
+    @Inject
+    private Gson gson;
+
+    @PostConstruct
+    public void setup() {
+        if (client == null) {
+            throw new IllegalArgumentException("Client must be injected.");
+        }
+    }
+
+    @Override
+    public <T extends Indexable> T getDocumentById(String id, String index, String type, Class<T> clazz) throws ArchiveException {
+        try {
+            GetResponse response = client.prepareGet(index, type, id)
+                    .execute()
+                    .actionGet();
+            if (!response.isExists()) {
+                log.log(Level.WARNING, "Can't get document with id:  " + id + ". Document doesn't exists.");
+                return null;
+            }
+            if (response.isSourceEmpty()) {
+                log.log(Level.WARNING, "Can't get document with id:  " + id + ". Elastic returned empty source.");
+                return null;
+            }
+            T document = gson.fromJson(response.getSourceAsString(), clazz);
+            document.setDocumentId(response.getId());
+            return document;
+        } catch (Exception ex) {
+            log.log(Level.SEVERE, "Getting document by id from elastic failed: " + ex.getMessage());
+            ex.printStackTrace();
+            throw new ArchiveException("Getting object by id failed", ex);
+        }
+    }
+
+    @Override
+    public <T extends Indexable> List<T> search(QueryBuilder query, SortBuilder sort, String index, String type, Class<T> clazz) throws ArchiveException {
+        return search(query, sort, index, type, 0, DEF_LIMIT, clazz);
+    }
+
+    @Override
+    public <T extends Indexable> List<T> search(final QueryBuilder query,
+                                                final SortBuilder sort,
+                                                final String index,
+                                                final String type,
+                                                final int from,
+                                                final int size,
+                                                final Class<T> clazz) throws ArchiveException {
+        try {
+            final SearchRequestBuilder search = client.prepareSearch(index)
+                    .setQueryCache(false)
+                    .setExplain(true)
+                    .setTypes(type)
+                    .setFrom(from)
+                    .setSize(size)
+                    .setQuery(query)
+                    .setSearchType(SearchType.DFS_QUERY_THEN_FETCH);
+            if (sort != null) {
+                search.addSort(sort);
+            }
+
+            final SearchResponse response = search.execute()
+                    .actionGet();
+            if (response.isTimedOut()) {
+                throw new ArchiveException("Elastic search timed out");
+            }
+//            if (response.isTerminatedEarly()) {
+//                throw new ArchiveException("Elastic search has been terminated early");
+//            }
+            if (!RestStatus.OK.equals(response.status())) {
+                throw new ArchiveException("Elastic search has not ended successfully: " + response.status());
+            }
+            if (response.getHits() == null || response.getHits().totalHits() == 0) {
+                return new ArrayList<>();
+            } else {
+                List<T> docs = new ArrayList<>((int) response.getHits().getTotalHits());
+                for (SearchHit hit : response.getHits()) {
+                    T doc = gson.fromJson(hit.sourceAsString(), clazz);
+                    doc.setDocumentId(hit.getId());
+                    docs.add(doc);
+                }
+                return docs;
+            }
+        } catch (Exception ex) {
+            log.log(Level.SEVERE, "Elastic search has failed: " + ex.getMessage());
+            ex.printStackTrace();
+            throw new ArchiveException("Elastic search has failed", ex);
+        }
+    }
+
+    @Override
+    public <T extends Indexable> T index(final T document, String index, String type) throws ArchiveException {
+        try {
+            final IndexResponse response = client.prepareIndex(index, type)
+                    .setId(document.getDocumentId()) // can be null in that case is id created
+                    .setRefresh(true)
+                    .setSource(gson.toJson(document))
+                    .execute()
+                    .actionGet();
+            document.setDocumentId(response.getId());
+            return document;
+        } catch (Exception ex) {
+            log.log(Level.SEVERE, "Indexing document failed: " + ex.getMessage());
+            ex.printStackTrace();
+            throw new ArchiveException("Indexing document failed", ex);
+        }
+    }
+
+    @Override
+    public boolean update(String documentId, Object updateDoc, String index, String type, Object upsertDoc) throws ArchiveException {
+        try {
+            UpdateRequestBuilder update = client.prepareUpdate(index, type, documentId)
+                    .setDoc(gson.toJson(updateDoc))
+                    .setRefresh(true)
+                    .setRetryOnConflict(5);
+            if (upsertDoc != null) {
+                IndexRequest upsert = new IndexRequest(index, type, documentId)
+                        .source(gson.toJson(upsertDoc));
+                update.setUpsert(upsert);
+            }
+            update.execute().actionGet();
+            return true;
+        } catch (Exception ex) {
+            log.log(Level.SEVERE, "Upsert went wrong: " + ex.getMessage());
+            ex.printStackTrace();
+            throw new ArchiveException("Upsert went wrong: " + ex.getMessage());
+        }
+    }
+
+    @Override
+    public <T extends Indexable> boolean delete(final T document, String index, String type) throws ArchiveException {
+        try {
+            final DeleteResponse response = client.prepareDelete(index, type, document.getDocumentId())
+                    .setRefresh(true)
+                    .execute()
+                    .actionGet();
+            return response.isFound();
+        } catch (Exception ex) {
+            log.log(Level.SEVERE, "Delete went wrong: " + ex.getMessage());
+            ex.printStackTrace();
+            throw new ArchiveException("Delete went wrong: " + ex.getMessage());
+        }
+    }
+}

--- a/ejb/src/main/java/biz/karms/sinkit/ejb/elastic/impl/ElasticServiceEJB.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ejb/elastic/impl/ElasticServiceEJB.java
@@ -1,16 +1,19 @@
 package biz.karms.sinkit.ejb.elastic.impl;
 
-import biz.karms.sinkit.ejb.elastic.ElasticService;
 import biz.karms.sinkit.ejb.elastic.Indexable;
 import biz.karms.sinkit.exception.ArchiveException;
 import io.searchbox.client.JestClient;
 import io.searchbox.client.JestResult;
-import io.searchbox.core.*;
+import io.searchbox.core.Delete;
+import io.searchbox.core.Get;
+import io.searchbox.core.Index;
+import io.searchbox.core.Search;
+import io.searchbox.core.SearchResult;
+import io.searchbox.core.Update;
 import io.searchbox.params.Parameters;
 import org.apache.commons.collections.CollectionUtils;
 
 import javax.annotation.PostConstruct;
-import javax.ejb.Stateless;
 import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.List;
@@ -20,8 +23,8 @@ import java.util.logging.Logger;
 /**
  * Created by tkozel on 4.8.15.
  */
-@Stateless
-public class ElasticServiceEJB implements ElasticService {
+//@Stateless
+public class ElasticServiceEJB /*implements ElasticService*/ {
 
     private static final String PARAMETER_FROM = "from";
     private static final int DEF_LIMIT = 1000;
@@ -52,7 +55,7 @@ public class ElasticServiceEJB implements ElasticService {
      * @return Found object of class T
      * @throws ArchiveException when communication with elastic went wrong or more than single hit is found
      */
-    @Override
+    //@Override
     public <T extends Indexable> T searchForSingleHit(String query, String index, String type, Class<T> clazz) throws ArchiveException {
         final List<T> hits = this.search(query, index, type, clazz);
         if (CollectionUtils.isEmpty(hits)) {
@@ -64,7 +67,7 @@ public class ElasticServiceEJB implements ElasticService {
         return hits.get(0);
     }
 
-    @Override
+    //@Override
     public <T extends Indexable> T getDocumentById(String id, String index, String type, Class<T> clazz) throws ArchiveException {
         JestResult result;
         T document;
@@ -98,7 +101,7 @@ public class ElasticServiceEJB implements ElasticService {
      * @return Found objects of class T
      * @throws ArchiveException when communication with elastic went wrong
      */
-    @Override
+    //@Override
     public <T extends Indexable> List<T> search(String query, String index, String type, Class<T> clazz) throws ArchiveException {
         return search(query, index, type, 0, DEF_LIMIT, clazz);
     }
@@ -117,7 +120,7 @@ public class ElasticServiceEJB implements ElasticService {
      * @return Found objects of class T
      * @throws ArchiveException when communication with elastic went wrong
      */
-    @Override
+    //@Override
     public <T extends Indexable> List<T> search(String query, String index, String type, int from, int size, Class<T> clazz) throws ArchiveException {
         Search search = new Search.Builder(query)
                 .addIndex(index)
@@ -164,7 +167,7 @@ public class ElasticServiceEJB implements ElasticService {
      * @return indexed object
      * @throws ArchiveException when communication with Elastic Search server went wrong
      */
-    @Override
+    //@Override
     public <T extends Indexable> T index(T document, String index, String type) throws ArchiveException {
         Index indexRequest = new Index.Builder(document)
                 .index(index)
@@ -201,7 +204,7 @@ public class ElasticServiceEJB implements ElasticService {
      * @return indexed object
      * @throws ArchiveException when communication with Elastic Search server went wrong
      */
-    @Override
+    //@Override
     public boolean update(String documentId, String script, String index, String type) throws ArchiveException {
 
         Update updateRequest = new Update.Builder(script)
@@ -235,7 +238,7 @@ public class ElasticServiceEJB implements ElasticService {
         return result.isSucceeded();
     }
 
-    @Override
+    //@Override
     public <T extends Indexable> boolean delete(T document, String index, String type) throws ArchiveException {
 
         JestResult result;
@@ -266,4 +269,14 @@ public class ElasticServiceEJB implements ElasticService {
 
         return result.isSucceeded();
     }
+
+//    @Override
+//    public void refresh() {
+//        //noop
+//    }
+//
+//    @Override
+//    public List<IoCRecord> findIoCsForDeactivation(String tooOld) throws ArchiveException {
+//        return null;
+//    }
 }

--- a/ejb/src/main/java/biz/karms/sinkit/ejb/impl/ArchiveServiceEJB.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ejb/impl/ArchiveServiceEJB.java
@@ -258,7 +258,7 @@ public class ArchiveServiceEJB implements ArchiveService {
         final String notAllowedFailedRange = "\"now-" + notAllowedFailedMinutes + "m\"";
         return "    \"query\":{\n" +
                 "        \"bool\":{\n" +
-                "            \"filter\":{\n" +
+                "            \"must\":{\n" +
                 "                \"term\":{\n" +
                 "                    \"virus_total_request.status\":" + statusTerm + "\n" +
                 "                }\n" +

--- a/ejb/src/main/java/biz/karms/sinkit/ejb/impl/ArchiveServiceEJB.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ejb/impl/ArchiveServiceEJB.java
@@ -8,9 +8,14 @@ import biz.karms.sinkit.eventlog.VirusTotalRequestStatus;
 import biz.karms.sinkit.exception.ArchiveException;
 import biz.karms.sinkit.ioc.IoCRecord;
 import biz.karms.sinkit.ioc.IoCVirusTotalReport;
-import com.google.gson.FieldNamingPolicy;
-import com.google.gson.GsonBuilder;
+import com.google.gson.Gson;
 import org.apache.commons.collections.CollectionUtils;
+import org.elasticsearch.index.query.FilterBuilders;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.sort.SortBuilder;
+import org.elasticsearch.search.sort.SortBuilders;
+import org.elasticsearch.search.sort.SortOrder;
 
 import javax.ejb.EJB;
 import javax.ejb.Stateless;
@@ -18,9 +23,14 @@ import javax.inject.Inject;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import static biz.karms.sinkit.ejb.elastic.ElasticResources.ELASTIC_DATE_FORMAT;
 
 /**
  * @author Tomas Kozel
@@ -33,11 +43,13 @@ public class ArchiveServiceEJB implements ArchiveService {
     public static final String ELASTIC_LOG_INDEX = "logs";
     public static final String ELASTIC_LOG_TYPE = "match";
 
-    private static final String ELASTIC_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ssZ";
     private static final DateFormat DATEFORMATTER = new SimpleDateFormat(ELASTIC_DATE_FORMAT);
 
     @Inject
     private Logger log;
+
+    @Inject
+    private Gson gson;
 
     @EJB
     private ElasticService elasticService;
@@ -49,47 +61,54 @@ public class ArchiveServiceEJB implements ArchiveService {
         c.add(Calendar.HOUR, -hours);
         final String tooOld = DATEFORMATTER.format(c.getTime());
 
-        final String query = "{\n" +
-                "   \"query\": {\n" +
-                "       \"filtered\": {\n" +
-                "           \"query\": {\n" +
-                "               \"term\": {\n" +
-                "                   \"active\": true\n" +
-                "               }\n" +
-                "           }\n," +
-                "           \"filter\": {\n" +
-                "               \"range\": {\n" +
-                "                   \"seen.last\": {\n" +
-                "                       \"lt\" : \"" + tooOld + "\"\n" +
-                "                   }\n" +
-                "               }\n" +
-                "           }\n" +
-                "       }\n" +
-                "   }\n" +
-                "}\n";
+//        final String query = "{\n" +
+//                "   \"query\": {\n" +
+//                "       \"filtered\": {\n" +
+//                "           \"query\": {\n" +
+//                "               \"term\": {\n" +
+//                "                   \"active\": true\n" +
+//                "               }\n" +
+//                "           }\n," +
+//                "           \"filter\": {\n" +
+//                "               \"range\": {\n" +
+//                "                   \"seen.last\": {\n" +
+//                "                       \"lt\" : \"" + tooOld + "\"\n" +
+//                "                   }\n" +
+//                "               }\n" +
+//                "           }\n" +
+//                "       }\n" +
+//                "   }\n" +
+//                "}\n";
 
-        return elasticService.search(query, ELASTIC_IOC_INDEX, ELASTIC_IOC_TYPE, IoCRecord.class);
+        final QueryBuilder query = QueryBuilders.filteredQuery(
+                QueryBuilders.termQuery("active", true),
+                FilterBuilders.rangeFilter("seen.last").lt(tooOld)
+        );
+
+        return elasticService.search(query, null, ELASTIC_IOC_INDEX, ELASTIC_IOC_TYPE, IoCRecord.class);
+        //return elasticService.findIoCsForDeactivation(tooOld);
     }
 
     @Override
     public List<IoCRecord> findIoCsForWhitelisting(final String sourceId) throws ArchiveException {
         //log.info("Searching archive for active IoCs with seen.last older than " + hours + " hours.");
-        final String query_string = "\"active: true AND NOT whitelist_name: * AND " +
-                "(source.id.value: " + sourceId + " OR source.id.value: *." + sourceId + ")\"";
-        final String query = "{\n" +
-                "   \"query\": {\n" +
-                "       \"filtered\": {\n" +
-                "           \"query\": {\n" +
-                "               \"query_string\": {\n" +
-                "                   \"query\": " + query_string + ",\n" +
-                "                   \"analyze_wildcard\": true\n" +
-                "               }\n" +
-                "           }\n" +
-                "       }\n" +
-                "   }\n" +
-                "}\n";
+        final String queryString = "active: true AND NOT whitelist_name: * AND " +
+                "(source.id.value: " + sourceId + " OR source.id.value: *." + sourceId + ")";
+//        final String query = "{\n" +
+//                "   \"query\": {\n" +
+//                "       \"filtered\": {\n" +
+//                "           \"query\": {\n" +
+//                "               \"query_string\": {\n" +
+//                "                   \"query\": " + query_string + ",\n" +
+//                "                   \"analyze_wildcard\": true\n" +
+//                "               }\n" +
+//                "           }\n" +
+//                "       }\n" +
+//                "   }\n" +
+//                "}\n";
 
-        return elasticService.search(query, ELASTIC_IOC_INDEX, ELASTIC_IOC_TYPE, IoCRecord.class);
+        final QueryBuilder query = QueryBuilders.queryStringQuery(queryString).analyzeWildcard(true);
+        return elasticService.search(query, null, ELASTIC_IOC_INDEX, ELASTIC_IOC_TYPE, IoCRecord.class);
     }
 
     @Override
@@ -98,35 +117,31 @@ public class ArchiveServiceEJB implements ArchiveService {
         ioc.setDocumentId(IoCIdentificationUtils.computeHashedId(ioc));
         //compute uniqueReference
         ioc.setUniqueRef(IoCIdentificationUtils.computeUniqueReference(ioc));
-        final String seenLast = DATEFORMATTER.format(ioc.getSeen().getLast());
-        final String upsertScript = "{\n" +
-                "    \"script\" : \"ctx._source.seen.last = seenLast\"\n," +
-                "    \"params\" : {\n" +
-                "        \"seenLast\" : \"" + seenLast + "\"\n" +
-                "    },\n" +
-                "   \"upsert\" : " + new GsonBuilder()
-                .setDateFormat(ELASTIC_DATE_FORMAT)
-                .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
-                .create()
-                .toJson(ioc) + "\n" +
-                "}";
-        return elasticService.update(ioc.getDocumentId(), upsertScript, ELASTIC_IOC_INDEX, ELASTIC_IOC_TYPE);
+//        final String seenLast = DATEFORMATTER.format(ioc.getSeen().getLast());
+//        final String upsertScript = "{\n" +
+//                "    \"script\" : \"ctx._source.seen.last = seenLast\"\n," +
+//                "    \"params\" : {\n" +
+//                "        \"seenLast\" : \"" + seenLast + "\"\n" +
+//                "    },\n" +
+//                "   \"upsert\" : " + gson.toJson(ioc) + "\n" +
+//                "}";
+        final Map<String, Map<String, Date>> seenLast = new HashMap<>();
+        seenLast.put("seen", new HashMap<>());
+        seenLast.get("seen").put("last", ioc.getSeen().getLast());
+        return elasticService.update(ioc.getDocumentId(), seenLast, ELASTIC_IOC_INDEX, ELASTIC_IOC_TYPE, ioc);
     }
 
     @Override
     public boolean setVirusTotalReportToIoCRecord(final IoCRecord ioc, final IoCVirusTotalReport[] reports) throws ArchiveException {
-        final String updateScript = "{\n" +
-                "   \"doc\" : {\n" +
-                "       \"virus_total_reports\" : " +
-                new GsonBuilder()
-                        .setDateFormat(ELASTIC_DATE_FORMAT)
-                        .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
-                        .create()
-                        .toJson(reports) + "\n" +
-                "   }\n" +
-                "}";
-        ioc.setVirusTotalReports(reports);
-        return elasticService.update(ioc.getDocumentId(), updateScript, ELASTIC_IOC_INDEX, ELASTIC_IOC_TYPE);
+//        final String updateScript = "{\n" +
+//                "   \"doc\" : {\n" +
+//                "       \"virus_total_reports\" : " +
+//                        gson.toJson(reports) + "\n" +
+//                "   }\n" +
+//                "}";
+        final Map<String, IoCVirusTotalReport[]> vtReports = new HashMap<>();
+        vtReports.put("virus_total_reports", reports);
+        return elasticService.update(ioc.getDocumentId(), vtReports, ELASTIC_IOC_INDEX, ELASTIC_IOC_TYPE, null);
     }
 
     @Override
@@ -166,23 +181,28 @@ public class ArchiveServiceEJB implements ArchiveService {
     @Override
     public List<IoCRecord> getActiveNotWhitelistedIoCs(final int from, final int size) throws ArchiveException {
         //log.info("Searching archive for active IoCs with seen.last older than " + hours + " hours.");
-        final String query = "{\n" +
-                "   \"query\":{\n" +
-                "       \"filtered\":{\n" +
-                "           \"query\":{\n" +
-                "               \"term\":{\n" +
-                "                   \"active\":true\n" +
-                "               }\n" +
-                "           },\n" +
-                "           \"filter\":{\n" +
-                "               \"missing\":{\n" +
-                "                   \"field\":\"whitelist_name\"\n" +
-                "               }\n" +
-                "           }\n" +
-                "       }\n" +
-                "   }\n" +
-                "}\n";
-        return elasticService.search(query, ELASTIC_IOC_INDEX, ELASTIC_IOC_TYPE, from, size, IoCRecord.class);
+//        final String query = "{\n" +
+//                "   \"query\":{\n" +
+//                "       \"filtered\":{\n" +
+//                "           \"query\":{\n" +
+//                "               \"term\":{\n" +
+//                "                   \"active\":true\n" +
+//                "               }\n" +
+//                "           },\n" +
+//                "           \"filter\":{\n" +
+//                "               \"missing\":{\n" +
+//                "                   \"field\":\"whitelist_name\"\n" +
+//                "               }\n" +
+//                "           }\n" +
+//                "       }\n" +
+//                "   }\n" +
+//                "}\n";
+        final QueryBuilder query = QueryBuilders.filteredQuery(
+                QueryBuilders.termQuery("active", true),
+                FilterBuilders.missingFilter("whitelist_name")
+        );
+
+        return elasticService.search(query, null, ELASTIC_IOC_INDEX, ELASTIC_IOC_TYPE, from, size, IoCRecord.class);
     }
 
     @Override
@@ -193,15 +213,18 @@ public class ArchiveServiceEJB implements ArchiveService {
 
     @Override
     public IoCRecord getIoCRecordByUniqueRef(final String uniqueRef) throws ArchiveException {
-        final String query = "{\n" +
-                "   \"query\": {\n" +
-                "               \"term\": {\n" +
-                "                   \"unique_ref\": \"" + uniqueRef + "\"\n" +
-                "               }\n" +
-                "   },\n" +
-                "   \"sort\": { \"time.received_by_core\": { \"order\": \"desc\" }}\n" +
-                "}\n";
-        final List<IoCRecord> iocs = elasticService.search(query, ELASTIC_IOC_INDEX, ELASTIC_IOC_TYPE, IoCRecord.class);
+//        final String query = "{\n" +
+//                "   \"query\": {\n" +
+//                "               \"term\": {\n" +
+//                "                   \"unique_ref\": \"" + uniqueRef + "\"\n" +
+//                "               }\n" +
+//                "   },\n" +
+//                "   \"sort\": { \"time.received_by_core\": { \"order\": \"desc\" }}\n" +
+//                "}\n";
+        final QueryBuilder query = QueryBuilders.termQuery("unique_ref", uniqueRef);
+        final SortBuilder sort = SortBuilders.fieldSort("time.received_by_core").order(SortOrder.DESC);
+
+        final List<IoCRecord> iocs = elasticService.search(query, sort, ELASTIC_IOC_INDEX, ELASTIC_IOC_TYPE, IoCRecord.class);
         if (CollectionUtils.isEmpty(iocs)) {
             return null;
         }
@@ -214,16 +237,19 @@ public class ArchiveServiceEJB implements ArchiveService {
 
     @Override
     public EventLogRecord getLogRecordWaitingForVTScan(final int notAllowedFailedMinutes) throws ArchiveException {
-        String query = "{\n" +
-                getWaitingLogRecordQuery(VirusTotalRequestStatus.WAITING, notAllowedFailedMinutes) + ",\n" +
-                "   \"sort\":{\n" +
-                "       \"logged\":{\n" +
-                "           \"order\":\"asc\"\n" +
-                "       }\n" +
-                "   }\n" +
-                "}";
+//        String query = "{\n" +
+//                getWaitingLogRecordQuery(VirusTotalRequestStatus.WAITING, notAllowedFailedMinutes) + ",\n" +
+//                "   \"sort\":{\n" +
+//                "       \"logged\":{\n" +
+//                "           \"order\":\"asc\"\n" +
+//                "       }\n" +
+//                "   }\n" +
+//                "}";
+
+        final QueryBuilder query = getWaitingLogRecordQuery(VirusTotalRequestStatus.WAITING, notAllowedFailedMinutes);
+        final SortBuilder sort = SortBuilders.fieldSort("logged").order(SortOrder.ASC);
         final List<EventLogRecord> logRecords =
-                elasticService.search(query, ELASTIC_LOG_INDEX + "-*",
+                elasticService.search(query, sort ,ELASTIC_LOG_INDEX + "-*",
                         ELASTIC_LOG_TYPE, 0, 1, EventLogRecord.class);
         if (CollectionUtils.isEmpty(logRecords)) {
             return null;
@@ -233,18 +259,22 @@ public class ArchiveServiceEJB implements ArchiveService {
 
     @Override
     public EventLogRecord getLogRecordWaitingForVTReport(final int notAllowedFailedMinutes) throws ArchiveException {
-        String query = "{\n" +
-                getWaitingLogRecordQuery(VirusTotalRequestStatus.WAITING_FOR_REPORT, notAllowedFailedMinutes) + ",\n" +
-                "   \"sort\":{\n" +
-                "       \"virus_total_request.processed\":{\n" +
-                "           \"order\": \"asc\",\n" +
-                "           \"ignore_unmapped\" : true\n" +
-                "       }\n" +
-                "   }\n" +
-                "}";
+//        String query = "{\n" +
+//                getWaitingLogRecordQuery(VirusTotalRequestStatus.WAITING_FOR_REPORT, notAllowedFailedMinutes) + ",\n" +
+//                "   \"sort\":{\n" +
+//                "       \"virus_total_request.processed\":{\n" +
+//                "           \"order\": \"asc\",\n" +
+//                "           \"ignore_unmapped\" : true\n" +
+//                "       }\n" +
+//                "   }\n" +
+//                "}";
 
+        final QueryBuilder query = getWaitingLogRecordQuery(VirusTotalRequestStatus.WAITING_FOR_REPORT, notAllowedFailedMinutes);
+        final SortBuilder sort = SortBuilders.fieldSort("virus_total_request.processed")
+                .order(SortOrder.ASC)
+                .unmappedType("date");
         final List<EventLogRecord> logRecords =
-                elasticService.search(query, ELASTIC_LOG_INDEX + "-*",
+                elasticService.search(query, sort, ELASTIC_LOG_INDEX + "-*",
                         ELASTIC_LOG_TYPE, 0, 1, EventLogRecord.class);
         if (CollectionUtils.isEmpty(logRecords)) {
             return null;
@@ -253,24 +283,33 @@ public class ArchiveServiceEJB implements ArchiveService {
         return logRecords.get(0);
     }
 
-    private String getWaitingLogRecordQuery(final VirusTotalRequestStatus status, final int notAllowedFailedMinutes) {
-        final String statusTerm = new GsonBuilder().create().toJson(status);
+    private QueryBuilder getWaitingLogRecordQuery(final VirusTotalRequestStatus status, final int notAllowedFailedMinutes) {
+        final String statusTerm = gson.toJson(status).replace("\"","");
         final String notAllowedFailedRange = "\"now-" + notAllowedFailedMinutes + "m\"";
-        return "    \"query\":{\n" +
-                "        \"bool\":{\n" +
-                "            \"must\":{\n" +
-                "                \"term\":{\n" +
-                "                    \"virus_total_request.status\":" + statusTerm + "\n" +
-                "                }\n" +
-                "            },\n" +
-                "            \"must_not\":{\n" +
-                "                \"range\":{\n" +
-                "                    \"virus_total_request.failed\":{\n" +
-                "                        \"gt\":" + notAllowedFailedRange + "\n" +
-                "                    }\n" +
-                "                }\n" +
-                "            }\n" +
-                "        }\n" +
-                "    }";
+        return QueryBuilders.boolQuery()
+                .must(QueryBuilders.termQuery("virus_total_request.status", statusTerm))
+                .mustNot(QueryBuilders.rangeQuery("virus_total_request.failed").gt(notAllowedFailedRange));
+
+//        return "    \"query\":{\n" +
+//                "        \"bool\":{\n" +
+//                "            \"must\":{\n" +
+//                "                \"term\":{\n" +
+//                "                    \"virus_total_request.status\":" + statusTerm + "\n" +
+//                "                }\n" +
+//                "            },\n" +
+//                "            \"must_not\":{\n" +
+//                "                \"range\":{\n" +
+//                "                    \"virus_total_request.failed\":{\n" +
+//                "                        \"gt\":" + notAllowedFailedRange + "\n" +
+//                "                    }\n" +
+//                "                }\n" +
+//                "            }\n" +
+//                "        }\n" +
+//                "    }";
     }
+
+//    @Override
+//    public void refresh() {
+//        elasticService.refresh();
+//    }
 }

--- a/ejb/src/main/java/biz/karms/sinkit/eventlog/EventLogRecord.java
+++ b/ejb/src/main/java/biz/karms/sinkit/eventlog/EventLogRecord.java
@@ -3,7 +3,6 @@ package biz.karms.sinkit.eventlog;
 import biz.karms.sinkit.ejb.elastic.Indexable;
 import biz.karms.sinkit.ioc.IoCRecord;
 import com.google.gson.annotations.SerializedName;
-import io.searchbox.annotations.JestId;
 
 import java.util.Arrays;
 import java.util.Date;
@@ -15,7 +14,7 @@ public class EventLogRecord implements Indexable {
 
     private static final long serialVersionUID = 423449239443309837L;
 
-    @JestId
+    //@JestId
     private transient String documentId;
 
     private EventLogAction action;

--- a/ejb/src/main/java/biz/karms/sinkit/ioc/IoCRecord.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ioc/IoCRecord.java
@@ -2,7 +2,6 @@ package biz.karms.sinkit.ioc;
 
 import biz.karms.sinkit.ejb.elastic.Indexable;
 import com.google.gson.annotations.SerializedName;
-import io.searchbox.annotations.JestId;
 
 import java.util.Arrays;
 
@@ -15,7 +14,7 @@ public class IoCRecord implements Indexable {
 
     private static final long serialVersionUID = -595246622767555283L;
 
-    @JestId
+    //@JestId
     @SerializedName("document_id")
     private String documentId;
     @SerializedName("unique_ref")

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
 
         <!-- Elastic Search -->
         <io.searchbox.jest.version>0.1.7</io.searchbox.jest.version>
+        <es.version>1.7.4</es.version>
 
         <!-- Virus Total -->
         <com.kanishka.api.VirustotalPublicV2.0.version>1.1.GA-SNAPSHOT</com.kanishka.api.VirustotalPublicV2.0.version>


### PR DESCRIPTION
Lightweight Elastic Search client has been replaced by Elastic Search native Java client. Client simulates a node which doesn't store data and connects to the cluster automatically. Logic remains the same until we know this is the right way and than we can design and implement bulk and async communication with archive. 

Classes of old client remain in repo until we verify the new client works properly and we can remove the old client completely.

Version of wildfly in docker file has been reverted.