### PR TITLE
Logging using logstash

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A prototype of a toy project featuring Infinispan dist cache.
     export SINKIT_GSB_API_KEY=
     export SINKIT_GSB_FULLHASH_URL=
     export SINKIT_WHITELIST_VALID_HOURS=
+    export SINKIT_LOGSTASH_URL=
 
 ## Basic config
 ###Feeds configurations

--- a/circle.yml
+++ b/circle.yml
@@ -24,6 +24,7 @@ machine:
     SINKIT_GSB_API_KEY: blablabla
     SINKIT_GSB_FULLHASH_URL: http://localhost:8080/sinkit/rest/gsbapitest/fullhash
     SINKIT_WHITELIST_VALID_HOURS: 1
+    # SINKIT_LOGSTASH_URL: http://localhost:9090/
     JAVA_HOME:
 dependencies:
   cache_directories:

--- a/ejb/src/main/java/biz/karms/sinkit/ejb/ArchiveService.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ejb/ArchiveService.java
@@ -26,6 +26,8 @@ public interface ArchiveService {
 
     EventLogRecord archiveEventLogRecord(EventLogRecord logRecord) throws ArchiveException;
 
+    EventLogRecord archiveEventLogRecordUsingLogstash(EventLogRecord logRecord) throws ArchiveException;
+
     List<IoCRecord> getActiveNotWhitelistedIoCs(int from, int size) throws ArchiveException;
 
     IoCRecord getIoCRecordById(String id) throws ArchiveException;

--- a/ejb/src/main/java/biz/karms/sinkit/ejb/elastic/ElasticResources.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ejb/elastic/ElasticResources.java
@@ -1,5 +1,7 @@
 package biz.karms.sinkit.ejb.elastic;
 
+import biz.karms.sinkit.ejb.elastic.logstash.LogstashClient;
+import biz.karms.sinkit.ejb.elastic.logstash.LogstashClientProvider;
 import com.google.gson.Gson;
 import org.elasticsearch.client.Client;
 
@@ -23,6 +25,9 @@ public class ElasticResources {
     private ElasticClientProvider elasticClientProvider;
 
     @Inject
+    private LogstashClientProvider logstashClientProvider;
+
+    @Inject
     private GsonProvider gsonProvider;
 
 //    @Produces
@@ -41,5 +46,11 @@ public class ElasticResources {
     @Default
     public Gson getGson() {
         return gsonProvider.getGson();
+    }
+
+    @Produces
+    @Default
+    public LogstashClient getLogstashClient() {
+        return logstashClientProvider.getLogstashClient();
     }
 }

--- a/ejb/src/main/java/biz/karms/sinkit/ejb/elastic/logstash/LogstashClient.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ejb/elastic/logstash/LogstashClient.java
@@ -1,0 +1,40 @@
+package biz.karms.sinkit.ejb.elastic.logstash;
+
+import biz.karms.sinkit.ejb.elastic.Indexable;
+import biz.karms.sinkit.exception.ArchiveException;
+import com.google.gson.Gson;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+/**
+ * Created by tkozel on 5/29/16.
+ */
+public class LogstashClient {
+
+    public static final String LOGSTASH_URL_ENV = "SINKIT_LOGSTASH_URL";
+    private static final String LOGSTASH_URL = (System.getenv().containsKey(LOGSTASH_URL_ENV)) ? System.getenv(LOGSTASH_URL_ENV) : "http://localhost:9090/";
+    private static final String RESPONSE_OK = "ok";
+
+    private Gson gson;
+
+    public LogstashClient(Gson gson) {
+        this.gson = gson;
+    }
+
+    public <T extends Indexable> boolean sentToLogstash(final T object, String index, String type) throws ArchiveException {
+        final Client client = ClientBuilder.newClient();
+        Response response = client.target(LOGSTASH_URL + "/" + index + "/" + type + "/")
+                .request()
+                .accept(MediaType.TEXT_PLAIN_TYPE)
+                .post(Entity.entity(gson.toJson(object), MediaType.APPLICATION_JSON_TYPE));
+        String responseMessage = response.readEntity(String.class);
+        if (!RESPONSE_OK.equals(responseMessage)) {
+            throw new ArchiveException("Unexpected Logstash response: " + responseMessage);
+        }
+        return true;
+    }
+}

--- a/ejb/src/main/java/biz/karms/sinkit/ejb/elastic/logstash/LogstashClientProvider.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ejb/elastic/logstash/LogstashClientProvider.java
@@ -1,0 +1,30 @@
+package biz.karms.sinkit.ejb.elastic.logstash;
+
+import com.google.gson.Gson;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Created by tkozel on 5/29/16.
+ */
+@ApplicationScoped
+public class LogstashClientProvider {
+    @Inject
+    private Logger log;
+
+    @Inject
+    private Gson gson;
+
+    private LogstashClient logstashClient;
+
+    public LogstashClient getLogstashClient() {
+        if (logstashClient == null) {
+            log.log(Level.INFO, "Logstash client doesn't exists, creating new one");
+            logstashClient = new LogstashClient(gson);
+        }
+        return logstashClient;
+    }
+}

--- a/logstash-sinkit.conf
+++ b/logstash-sinkit.conf
@@ -1,0 +1,13 @@
+input {
+  http {
+    port => 9090
+  }
+}
+output {
+  elasticsearch { 
+    hosts => ["localhost:9200"]
+    index => "logs-%{+YYYY-MM-dd}"
+    document_type => "match" 
+  }
+}
+

--- a/logstash-sinkit.conf
+++ b/logstash-sinkit.conf
@@ -3,6 +3,11 @@ input {
     port => 9090
   }
 }
+filter {
+  mutate {
+    remove_field => ["@version", "host", "headers"]
+  }
+}
 output {
   elasticsearch { 
     hosts => ["localhost:9200"]


### PR DESCRIPTION
- log records can by sent to elastic via logstash now
- this feature is disabled by default 
- can be turned on using env property SINKIT_LOGSTASH_URL=http://address_to_elastic:port/
- logstash has to be up and configured using logstash-sinkit.conf
