### PR TITLE
BUG: Added checks for nullity of accuracy

### DIFF
--- a/ejb/src/main/java/biz/karms/sinkit/ejb/impl/ArchiveServiceEJB.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ejb/impl/ArchiveServiceEJB.java
@@ -8,6 +8,7 @@ import biz.karms.sinkit.eventlog.EventLogRecord;
 import biz.karms.sinkit.eventlog.VirusTotalRequestStatus;
 import biz.karms.sinkit.exception.ArchiveException;
 import biz.karms.sinkit.ioc.IoCRecord;
+import biz.karms.sinkit.ioc.IoCSeen;
 import biz.karms.sinkit.ioc.IoCVirusTotalReport;
 import com.google.gson.Gson;
 import org.apache.commons.collections.CollectionUtils;
@@ -86,11 +87,13 @@ public class ArchiveServiceEJB implements ArchiveService {
         ioc.setDocumentId(IoCIdentificationUtils.computeHashedId(ioc));
         //compute uniqueReference
         ioc.setUniqueRef(IoCIdentificationUtils.computeUniqueReference(ioc));
-        final Map<String, Map<String, Object>> fieldsToUpdate = new HashMap<>();
-        HashMap<String, Object> lastseen = new HashMap<String, Object>();
-        lastseen.put("last", ioc.getSeen().getLast());
-        fieldsToUpdate.put("seen", lastseen);
-        fieldsToUpdate.put("accuracy", new HashMap<String, Object>(ioc.getAccuracy())); //need to convert <String,Integer> to <String,Object>
+
+        final IoCRecord fieldsToUpdate = new IoCRecord();
+        IoCSeen seen = new IoCSeen();
+        seen.setLast(ioc.getSeen().getLast());
+        fieldsToUpdate.setAccuracy(ioc.getAccuracy());
+        fieldsToUpdate.setSeen(seen);
+
         return elasticService.update(ioc.getDocumentId(), fieldsToUpdate, ELASTIC_IOC_INDEX, ELASTIC_IOC_TYPE, ioc);
     }
 

--- a/ejb/src/main/java/biz/karms/sinkit/ejb/impl/BlacklistCacheServiceEJB.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ejb/impl/BlacklistCacheServiceEJB.java
@@ -48,6 +48,12 @@ public class BlacklistCacheServiceEJB implements BlacklistCacheService {
             return false;
         }
 
+        if (ioCRecord.getAccuracy() == null) {
+            log.log(Level.INFO, "addToCache: ioCRecord has accuracy null.");
+            final HashMap<String, Integer> accuracy = new HashMap<>();
+            ioCRecord.setAccuracy(accuracy);
+        }
+
         log.log(Level.FINE, "PROCESSING IOC for Blacklistcache: " + new Gson().toJson(ioCRecord));
 
         final String md5Key = DigestUtils.md5Hex(ioCRecord.getSource().getId().getValue());

--- a/ejb/src/main/java/biz/karms/sinkit/ejb/impl/CoreServiceEJB.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ejb/impl/CoreServiceEJB.java
@@ -25,6 +25,7 @@ import javax.ejb.Stateless;
 import javax.inject.Inject;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;


### PR DESCRIPTION
In archive service, null accuracy is ok because of a new way of setting it
In blacklist service, I added a check