### PR TITLE
Added processor of redis iocs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,13 @@ jobs:
           SINKIT_WHITELIST_VALID_HOURS: 1
           SINKIT_MGMT_USER: user
           SINKIT_MGMT_PASS: user
+          SINKIT_REDIS_INTERVAL_SECONDS: 1
+          SINKIT_REDIS_HOST: 127.0.0.1
+          SINKIT_REDIS_PORT: 6379
+          SINKIT_REDIS_POPPER_ENABLE: True
+          SINKIT_REDIS_QUEUE: "iocs"
+          SINKIT_REDIS_PROCESSING_QUEUE: "processing"
+
 
 # ELASTIC
 # Image repo: https://github.com/hugeox/elastic-docker
@@ -60,6 +67,9 @@ jobs:
           INFINISPAN_MX_RAM: "2g"
           INFINISPAN_NIC: "lo"
           INFINISPAN_GMS_MAX_JOIN_ATTEMPTS: "1"
+
+#REDIS DB
+      - image: circleci/redis:4.0.9
     
     steps:
       - checkout

--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@
 ## Expected env vars
 
 see $PROJECT_HOME/.circleci/config.yml
+Note that SINKIT_REDIS_INTERVAL_SECONDS is used to set second in schedulerExpressions to "*/"+SINKIT_REDIS_INTERVAL_SECONDS - thus values that do not divide 60 will result in the intervals between timer triggerings being equal to SINKIT_REDIS_INTERVAL_SECONDS
+(i. e. for SINKIT_REDIS_INTERVAL_SECONDS = 11, the timer gets triggered at seconds 0,11,22,33,44,55, 0 again)
 
-## Run ISPN, Elastic
-They should run on ports 9200, 9300 (Elastic) and 11322(ISPN)
+## Run ISPN, Elastic, Redis
+They should run on ports 9200, 9300 (Elastic), 11322(ISPN) and 6379(redis)
 
 ## Initialize Elastic
 

--- a/ejb/src/main/java/biz/karms/sinkit/ejb/impl/ArchiveServiceEJB.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ejb/impl/ArchiveServiceEJB.java
@@ -178,7 +178,7 @@ public class ArchiveServiceEJB implements ArchiveService {
 
     @Override
     public IoCRecord getActiveIoCRecordById(final String id) throws ArchiveException {
-        //log.log(Level.WARNING, "getActiveIoCRecordById: id: "+id+", ELASTIC_IOC_INDEX: "+ELASTIC_IOC_INDEX+", ELASTIC_IOC_TYPE: "+ELASTIC_IOC_TYPE);
+        //log.log(Level.WARNING, "getActiveIoCRecordById: id: "+id+", ELASTIC_IOC_INDEX: "+ELASTIC_IOC_INDEX_ACTIVE+", ELASTIC_IOC_TYPE: "+ELASTIC_IOC_TYPE);
         return elasticService.getDocumentById(id, ELASTIC_IOC_INDEX_ACTIVE, ELASTIC_IOC_TYPE, IoCRecord.class);
     }
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -101,6 +101,14 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>redis.clients</groupId>
+            <artifactId>jedis</artifactId>
+            <version>${jedis.version}</version>
+            <type>jar</type>
+            <scope>compile</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/integration-tests/src/test/java/biz/karms/sinkit/tests/SinkitDeployment.java
+++ b/integration-tests/src/test/java/biz/karms/sinkit/tests/SinkitDeployment.java
@@ -2,6 +2,7 @@ package biz.karms.sinkit.tests;
 
 import biz.karms.sinkit.tests.api.ApiIntegrationTest;
 import biz.karms.sinkit.tests.core.CoreTest;
+import biz.karms.sinkit.tests.redis.RedisIntegrationTest;
 import biz.karms.sinkit.tests.util.IoCFactory;
 import biz.karms.sinkit.tests.whitelist.WhitelistCacheServiceTest;
 import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
@@ -23,19 +24,24 @@ import java.io.File;
  */
 @ArquillianSuiteDeployment
 public class SinkitDeployment {
-    @Deployment(name = "ear", testable = true, managed = true)
+    @Deployment(name = "ear", testable = true)
     public static Archive<?> createTestArchive() {
         EnterpriseArchive ear = ShrinkWrap.create(ZipImporter.class, "sinkit-ear.ear").importFrom(new File("../ear/target/sinkit-ear.ear")).as(EnterpriseArchive.class);
         ear.getAsType(JavaArchive.class, "sinkit-ejb.jar")
                 .addClass(CoreTest.class)
                 .addClass(ApiIntegrationTest.class)
+                .addClass(RedisIntegrationTest.class)
                 .addClass(WhitelistCacheServiceTest.class)
                 .addClass(FailingHttpStatusCodeException.class)
                 .addClass(IoCFactory.class)
                 .addClass(com.gargoylesoftware.htmlunit.HttpMethod.class)
                 .addClass(com.gargoylesoftware.htmlunit.Page.class)
                 .addClass(com.gargoylesoftware.htmlunit.WebClient.class)
-                .addClass(com.gargoylesoftware.htmlunit.WebRequest.class);
+                .addClass(com.gargoylesoftware.htmlunit.WebRequest.class)
+                .addClass(redis.clients.jedis.Jedis.class)
+                .addClass(biz.karms.sinkit.tests.util.FileUtils.class)
+                .addClass(org.hamcrest.core.Is.class)
+                .addClass(org.hamcrest.core.IsNull.class);
         //.addClass(DeploymentException.class);
         return ear;
     }

--- a/integration-tests/src/test/java/biz/karms/sinkit/tests/redis/RedisIntegrationTest.java
+++ b/integration-tests/src/test/java/biz/karms/sinkit/tests/redis/RedisIntegrationTest.java
@@ -1,0 +1,176 @@
+package biz.karms.sinkit.tests.redis;
+
+
+import biz.karms.sinkit.ejb.ArchiveService;
+import biz.karms.sinkit.ejb.BlacklistCacheService;
+import biz.karms.sinkit.ejb.CoreService;
+import biz.karms.sinkit.ejb.WebApi;
+import biz.karms.sinkit.ioc.IoCRecord;
+import biz.karms.sinkit.tests.util.FileUtils;
+import com.gargoylesoftware.htmlunit.HttpMethod;
+import com.gargoylesoftware.htmlunit.Page;
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.WebRequest;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.testng.Arquillian;
+import org.testng.annotations.Test;
+import redis.clients.jedis.Jedis;
+
+import javax.ejb.EJB;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * @author Michal Karm Babacek
+ */
+public class RedisIntegrationTest extends Arquillian {
+
+    private static final String REDIS_QUEUE = System.getenv("SINKIT_REDIS_QUEUE");
+    private static final String REDIS_PROCESSING_QUEUE = System.getenv("SINKIT_REDIS_PROCESSING_QUEUE");
+
+    @EJB
+    BlacklistCacheService blacklistCacheService;
+
+    @EJB
+    ArchiveService archiveService;
+
+    @EJB
+    CoreService coreService;
+
+    @EJB
+    WebApi webApi;
+
+    @Test(enabled = true, dataProvider = Arquillian.ARQUILLIAN_DATA_PROVIDER, priority = 401)
+    @OperateOnDeployment("ear")
+    @RunAsClient
+    public void redisTest(@ArquillianResource URL context) throws Exception {
+
+        //setup iocs
+        Jedis jedis = new Jedis(System.getenv("SINKIT_REDIS_HOST"), new Integer(System.getenv("SINKIT_REDIS_PORT")));
+        String iocNew1 = FileUtils.readFileIntoString("iocRedisNew1.json");
+        String iocNew2 = FileUtils.readFileIntoString("iocRedisNew2.json");
+        String iocOld = FileUtils.readFileIntoString("iocRedisOld.json");
+        Calendar c = Calendar.getInstance();
+        Date now = c.getTime();
+        c.add(Calendar.HOUR, -new Integer(System.getenv("SINKIT_IOC_ACTIVE_HOURS")));
+        Date tooOld = c.getTime();
+        c.add(Calendar.HOUR, 1);
+        iocNew1 = iocNew1.replace("TIME_OBSERVATION", new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX").format(now));
+        iocNew2 = iocNew2.replace("TIME_OBSERVATION", new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX").format(now));
+        iocOld = iocOld.replace("TIME_OBSERVATION", new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX").format(tooOld));
+
+        //send iocs to redis
+        jedis.lpush(REDIS_QUEUE, iocNew1, iocNew2, iocOld);
+
+        //wait a second for core to process iocs
+        Thread.sleep(3100);
+
+        //check redis
+        assertEquals(jedis.llen(REDIS_QUEUE), new Long(0));
+        //not even tooOld should stay in redis, as it is too old and we want to throw it away
+        assertEquals(jedis.llen(REDIS_PROCESSING_QUEUE), new Long(0));
+
+
+        //check cache, can be run as client;
+        //iocOld shouldn't be in cache - too old
+
+        checkCache("redisTest", "phishing", "fishingredis.ru", context);
+        checkCache("redisTest", "phishing", "otherphishingredis.ru", context);
+        checkNotInCache("redisTest", "phishing", "phishingtoooldredis.ru", context);
+        jedis.close();
+
+
+    }
+
+
+    //Can't be run as client!
+    @Test(enabled = true, dataProvider = Arquillian.ARQUILLIAN_DATA_PROVIDER, priority = 402)
+    public void RedisCheckElasticTest() throws Exception {
+        //check elastic
+        checkElastic("redisTest", "phishing", "fishingredis.ru");
+        checkElastic("redisTest", "phishing", "otherphishingredis.ru");
+        checkNotInElastic("redisTest", "phishing", "phishingtoooldredis.ru");
+
+    }
+
+
+    //Assumes time.deactivated is null for the ioc -
+    public void checkElastic(String feed, String type, String fqdn) throws Exception {
+
+        final StringBuilder idString = new StringBuilder();
+        idString.append(feed);
+        idString.append(type);
+        idString.append(fqdn);
+        String iocId = DigestUtils.md5Hex(idString.toString());
+
+        IoCRecord ioc = archiveService.getActiveIoCRecordById(iocId);
+        assertNotNull(ioc, "Excpecting IoC, but got null with fqdn: " + fqdn + ", type: " + type + ", feed: " + feed);
+        assertEquals(ioc.getFeed().getName(), feed, "Expected feed.name: " + feed + ", but got: " + ioc.getFeed().getName());
+        assertEquals(ioc.getSource().getId().getValue(), fqdn, "Expected source.id.value: " + fqdn + ", but got: " + ioc.getSource().getId().getValue());
+        assertEquals(ioc.getClassification().getType(), type, "Expected classification.type: " + type + ", but got: " + ioc.getClassification().getType());
+        assertNotNull(ioc.getSeen().getFirst(), "Expected seen.first but got null");
+        assertNotNull(ioc.getSeen().getLast(), "Expected seen.last but got null");
+        Calendar c = Calendar.getInstance();
+        c.add(Calendar.HOUR, -coreService.getIocActiveHours());
+        assertTrue(ioc.getSeen().getLast().after(c.getTime()), "Expected seen.last is not older than " + coreService.getIocActiveHours() + " hours, but got " + ioc.getSeen().getLast());
+        assertTrue(ioc.getActive(), "Expected ioc to be active, but got active: false");
+        assertNotNull(ioc.getTime().getObservation(), "Expecting time.observation, but got null");
+    }
+
+    public void checkNotInElastic(String feed, String type, String fqdn) throws Exception {
+
+        final StringBuilder idString = new StringBuilder();
+        idString.append(feed);
+        idString.append(type);
+        idString.append(fqdn);
+        String iocId = DigestUtils.md5Hex(idString.toString());
+
+        IoCRecord ioc = archiveService.getActiveIoCRecordById(iocId);
+        assertNull(ioc);
+    }
+
+    public void checkCache(String feed, String type, String fqdn, URL context) throws Exception {
+        final StringBuilder idString = new StringBuilder();
+        idString.append(feed);
+        idString.append(type);
+        idString.append(fqdn);
+        String iocId = DigestUtils.md5Hex(idString.toString());
+
+        String fqdnmd5 = DigestUtils.md5Hex(fqdn);
+
+        WebClient webClient = new WebClient();
+        WebRequest requestSettings = new WebRequest(new URL(context + "rest/blacklist/record/" + fqdn), HttpMethod.GET);
+        requestSettings.setAdditionalHeader("Content-Type", "application/json");
+        Page page = webClient.getPage(requestSettings);
+        assertEquals(HttpURLConnection.HTTP_OK, page.getWebResponse().getStatusCode());
+        String responseBody = page.getWebResponse().getContentAsString();
+        String expected = "\"black_listed_domain_or_i_p\":\"" + fqdnmd5 + "\"";  // md5 of phishing.ru
+        assertTrue(responseBody.contains(expected), "IoC response should have contained " + expected + ", but got:" + responseBody);
+        expected = "\"sources\":{\"" + feed + "\":{\"left\":\"" + type + "\",\"right\":\"" + iocId;
+        assertTrue(responseBody.contains(expected), "IoC should have contained " + expected + ", but got: " + responseBody);
+    }
+
+    public void checkNotInCache(String feed, String type, String fqdn, URL context) throws Exception {
+        String fqdnmd5 = DigestUtils.md5Hex(fqdn);
+
+        WebClient webClient = new WebClient();
+        WebRequest requestSettings = new WebRequest(new URL(context + "rest/blacklist/record/" + fqdn), HttpMethod.GET);
+        requestSettings.setAdditionalHeader("Content-Type", "application/json");
+        Page page = webClient.getPage(requestSettings);
+        assertEquals(HttpURLConnection.HTTP_OK, page.getWebResponse().getStatusCode());
+        String responseBody = page.getWebResponse().getContentAsString();
+
+        assertEquals(responseBody, "null");
+    }
+}

--- a/integration-tests/src/test/resources/iocRedisNew1.json
+++ b/integration-tests/src/test/resources/iocRedisNew1.json
@@ -1,0 +1,32 @@
+{
+  "feed": {
+    "name": "redisTest",
+    "url": "http://www.someFeed.com/feed.txt"
+  },
+  "classification": {
+    "type": "phishing",
+    "taxonomy": "Fraud"
+  },
+  "raw": "someRaw",
+  "source": {
+    "fqdn": "fishingredis.ru",
+    "bgp_prefix": "some_pre",
+    "asn": "12",
+    "asn_name": "some_asn_name",
+    "geolocation": {
+      "cc": "RU",
+      "city": "City",
+      "latitude": "85.12645",
+      "longitude": "-12.9788"
+    }
+  },
+  "time": {
+    "observation": "TIME_OBSERVATION"
+  },
+  "protocol": {
+    "application": "ssh"
+  },
+  "description": {
+    "text": "description"
+  }
+}

--- a/integration-tests/src/test/resources/iocRedisNew2.json
+++ b/integration-tests/src/test/resources/iocRedisNew2.json
@@ -1,0 +1,32 @@
+{
+  "feed": {
+    "name": "redisTest",
+    "url": "http://www.greatfeed.com/feed.txt"
+  },
+  "classification": {
+    "type": "phishing",
+    "taxonomy": "Fraud"
+  },
+  "raw": "RawforNewTwo",
+  "source": {
+    "fqdn": "otherphishingredis.ru",
+    "bgp_prefix": "some_prefix",
+    "asn": "123456",
+    "asn_name": "some_name",
+    "geolocation": {
+      "cc": "RU",
+      "city": "City",
+      "latitude": "85.12645",
+      "longitude": "-12.9788"
+    }
+  },
+  "time": {
+    "observation": "TIME_OBSERVATION"
+  },
+  "protocol": {
+    "application": "ssh"
+  },
+  "description": {
+    "text": "description"
+  }
+}

--- a/integration-tests/src/test/resources/iocRedisOld.json
+++ b/integration-tests/src/test/resources/iocRedisOld.json
@@ -1,0 +1,32 @@
+{
+  "feed": {
+    "name": "redisTest",
+    "url": "http://www.greatfeed.com/feed.txt"
+  },
+  "classification": {
+    "type": "phishing",
+    "taxonomy": "Fraud"
+  },
+  "raw": "rawtooold",
+  "source": {
+    "fqdn": "phishingtoooldredis.ru",
+    "bgp_prefix": "some_prefix",
+    "asn": "1234568",
+    "asn_name": "some_name",
+    "geolocation": {
+      "cc": "RU",
+      "city": "City",
+      "latitude": "85.12645",
+      "longitude": "-12.9788"
+    }
+  },
+  "time": {
+    "observation": "TIME_OBSERVATION"
+  },
+  "protocol": {
+    "application": "ssh"
+  },
+  "description": {
+    "text": "description"
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,8 @@
         <crc64.version>1.0.7</crc64.version>
 
         <hamcrest.version>2.0.0.0</hamcrest.version>
+        <jedis.version>3.0.1</jedis.version>
+
     </properties>
 
     <dependencyManagement>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -111,6 +111,14 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>redis.clients</groupId>
+            <artifactId>jedis</artifactId>
+            <version>${jedis.version}</version>
+            <type>jar</type>
+            <scope>compile</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/rest/src/main/java/biz/karms/sinkit/rest/RedisIocProcessor.java
+++ b/rest/src/main/java/biz/karms/sinkit/rest/RedisIocProcessor.java
@@ -1,0 +1,14 @@
+package biz.karms.sinkit.rest;
+
+import javax.ejb.Local;
+import java.util.HashMap;
+import java.util.concurrent.Future;
+
+/**
+ * @author Krystof Kolar
+ */
+@Local
+public interface RedisIocProcessor {
+
+    Future<HashMap<String, Integer>> runRedisIocProcessing() throws InterruptedException;
+}

--- a/rest/src/main/java/biz/karms/sinkit/rest/RedisIocProcessorEJB.java
+++ b/rest/src/main/java/biz/karms/sinkit/rest/RedisIocProcessorEJB.java
@@ -1,0 +1,83 @@
+package biz.karms.sinkit.rest;
+
+import biz.karms.sinkit.exception.IoCValidationException;
+import com.google.gson.JsonSyntaxException;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.JedisPoolConfig;
+
+import javax.annotation.PreDestroy;
+import javax.ejb.AsyncResult;
+import javax.ejb.Asynchronous;
+import javax.ejb.Singleton;
+import javax.inject.Inject;
+import java.util.HashMap;
+import java.util.concurrent.Future;
+import java.util.logging.Logger;
+
+/**
+ * @author Krystof Kolar
+ */
+@Singleton
+public class RedisIocProcessorEJB implements RedisIocProcessor {
+
+    private static final String QUEUE = System.getenv("SINKIT_REDIS_QUEUE");
+    private static final String PROCESSING_QUEUE = System.getenv("SINKIT_REDIS_PROCESSING_QUEUE");
+
+    @Inject
+    private Logger log;
+
+    @Inject
+    SinkitService sinkitService;
+
+    JedisPool pool = new JedisPool(new JedisPoolConfig(), System.getenv("SINKIT_REDIS_HOST"), new Integer(System.getenv("SINKIT_REDIS_PORT")));
+
+    @Asynchronous
+    @Override
+    public Future<HashMap<String, Integer>> runRedisIocProcessing() throws InterruptedException {
+        return new AsyncResult<>(processIocsFromRedis());
+
+    }
+
+    private HashMap<String, Integer> processIocsFromRedis() throws InterruptedException {
+        Integer discarded_counter = 0;
+        Integer failed_counter = 0;
+        Integer processed_counter = 0;
+        try (Jedis jedis = pool.getResource()) {
+            while (jedis.llen(QUEUE) > 0) {
+                String ioc = jedis.rpoplpush(QUEUE, PROCESSING_QUEUE);
+                try {
+                    sinkitService.processIoCRecord(ioc);
+                    jedis.lrem(PROCESSING_QUEUE, 1, ioc);
+                    processed_counter++;
+                } catch (IoCValidationException | JsonSyntaxException ex) {
+                    log.severe("Processing IoC went wrong: " + ex.getMessage());
+                    //Validation error. We don't want to try processing ioc anymore
+                    jedis.lrem(PROCESSING_QUEUE, 1, ioc);
+                    discarded_counter++;
+                    //TODO: Do something about it (maybe save to some db for manual inspection)
+                } catch (Exception ex) {
+                    //Some other error: do not remove ioc from processing queue
+                    log.severe("Processing IoC went wrong: " + ex.getMessage());
+                    failed_counter++;
+                }
+            }
+            //Move all entries from PROCESSING_QUEUE back to QUEUE (ordering is of no importance here)
+            while (jedis.llen(PROCESSING_QUEUE) > 0) {
+                jedis.rpoplpush(PROCESSING_QUEUE, QUEUE);
+            }
+        }
+        HashMap<String, Integer> stats = new HashMap<>(3);
+        stats.put("failed", failed_counter);
+        stats.put("discarded", discarded_counter);
+        stats.put("processed", processed_counter);
+        return stats;
+
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        log.info("Close Redis pool");
+        pool.close();
+    }
+}

--- a/rest/src/main/java/biz/karms/sinkit/rest/RedisSchedulerEJB.java
+++ b/rest/src/main/java/biz/karms/sinkit/rest/RedisSchedulerEJB.java
@@ -1,0 +1,79 @@
+package biz.karms.sinkit.rest;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.annotation.Resource;
+import javax.ejb.EJB;
+import javax.ejb.LocalBean;
+import javax.ejb.ScheduleExpression;
+import javax.ejb.Singleton;
+import javax.ejb.Startup;
+import javax.ejb.Timeout;
+import javax.ejb.Timer;
+import javax.ejb.TimerConfig;
+import javax.ejb.TimerService;
+import javax.inject.Inject;
+import java.util.HashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.logging.Logger;
+
+/**
+ * @author Krystof Kolar
+ */
+
+@Singleton
+@LocalBean
+@Startup
+public class RedisSchedulerEJB {
+
+
+    private static final boolean SINKIT_REDIS_POPPER_ENABLE = (System.getenv().containsKey(
+            "SINKIT_REDIS_POPPER_ENABLE"))
+            && Boolean.parseBoolean(System.getenv("SINKIT_REDIS_POPPER_ENABLE"));
+    @EJB
+    RedisIocProcessor redisIocProcessor;
+    @Inject
+    private Logger log;
+    @Resource
+    private TimerService timerService;
+    private Future<HashMap<String, Integer>> future = null;
+
+    @PostConstruct
+    private void initialize() {
+        if (SINKIT_REDIS_POPPER_ENABLE) {
+            Integer SINKIT_REDIS_INTERVAL_SECONDS = new Integer(5);
+            if (System.getenv().containsKey("SINKIT_REDIS_INTERVAL_SECONDS")) {
+                SINKIT_REDIS_INTERVAL_SECONDS = new Integer(System.getenv("SINKIT_REDIS_INTERVAL_SECONDS"));
+            }
+            timerService.createCalendarTimer(
+                    new ScheduleExpression().hour("*").minute("*").second("*/" + SINKIT_REDIS_INTERVAL_SECONDS),
+                    new TimerConfig("RedisPopper", false));
+        }
+    }
+
+    @PreDestroy
+    public void stop() {
+        log.info("Stop all RedisPopper timers");
+        for (Timer timer : timerService.getTimers()) {
+            log.fine("Stop RedisPopper timer: " + timer.getInfo());
+            timer.cancel();
+        }
+    }
+
+    @Timeout
+    public void scheduler(Timer timer) throws InterruptedException, ExecutionException {
+        log.severe("Redis Popper timer info: " + timer.getInfo());
+        if (future == null) {
+            log.fine("Starting redis processing.");
+            future = this.redisIocProcessor.runRedisIocProcessing();
+        } else if (future.isDone()) {
+            // can analyze results of operation
+            log.fine("Finished Redis processing run, ioc stats: " + future.get().toString());
+            log.fine("Starting another Redis processing run.");
+            future = this.redisIocProcessor.runRedisIocProcessing();
+        } else {
+            log.fine("Redis data processing still running");
+        }
+    }
+}


### PR DESCRIPTION
 This is my suggestion for the mechanism of processing iocs from redis.

I would like to discuss this:
1. code organization - I am not sure where to put the redis Scheduller and RedisIocProcessor classes - I feel like they don't belong to REST, but they do use SinkitService.
2. rollback mechanism - I am worried that if elastic or cache throw an error, but something has already been saved (into the other one), then we might get duplicities, because the way RedisIocProcessor works now is that if save doesn't succeed, it is tried again later and this could happen many times.